### PR TITLE
Update clang_format_custom.sublime-settings

### DIFF
--- a/clang_format_custom.sublime-settings
+++ b/clang_format_custom.sublime-settings
@@ -137,7 +137,7 @@
     // bool SplitEmptyFunction If false, empty function body can be put on a single line.
     // bool SplitEmptyRecord If false, empty record (e.g. class, struct or union) body can be put on a single line.
     // bool SplitEmptyNamespace If false, empty namespace body can be put on a single line.
-    "BraceWrapping":{
+//    "BraceWrapping":{
 //        "AfterClass":             false,
 //        "AfterControlStatement":  false,
 //        "AfterEnum":              false,
@@ -152,7 +152,7 @@
 //        "SplitEmptyFunction:"     true,
 //        "SplitEmptyRecord":       true,
 //        "SplitEmptyNamespace":    true
-    },
+//    },
 
     // Break after each annotation on a field in Java files.
 // "BreakAfterJavaFieldAnnotations": true,


### PR DESCRIPTION
The BraceWrapping option was uncommented, and causes a crash when formatting.